### PR TITLE
ci: remove publish from CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,3 @@
 language: node_js
 node_js:
 - '0.10'
-deploy:
-  provider: npm
-  email: open-source@goodeggs.com
-  api_key:
-    secure: dNzzHiFQr5sWdijCc8MHtHNZuATUP41k0r3h5QhSIzPF8tPBG+Be0dlBW5GJGJligQ4mucj28sgwOy++L9NDu17j2j9smFnRkfbCQaqkqvesKbym5oUJ8qNLK9rZW1Zjp5TcZtYdO+x5bnLAu+qydD3ntxObTtaiS+7FElM3v+A=
-  on:
-    tags: true
-    repo: goodeggs/connect-devicedetect


### PR DESCRIPTION
We revoked this token. This repo is deprecated so it isn't worth fixing.